### PR TITLE
#19 - Adicionando argumentos que possibilitam o pip de ser encontrado…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 *  Nova query que permite listar o usuários não ativados.
 *  Remoção de alguns campos da model Visitor
 
+## [0.2.0] - 2019-10-31
+### Alterado
+*  Argumento "python -m" adicionado antes do "pip install" no Dockerfile
+
 
 
  ---

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache \
 
 COPY docker/requirements.txt requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt
 
 COPY app/ .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache \
 
 COPY docker/requirements.txt requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --no-cache-dir -r requirements.txt
 
 COPY app/ .
 


### PR DESCRIPTION
… pelo pythonpath especificado

Co-authored-by: Mateus <mateusn@outlook.com>

Closes  #19 

## Descrição 

Adiciona argumentos que possibilitam o pip de ser encontrado pelo pythonpath especificado

## Alterações feitas

Argumento "python -m" adicionado antes do "pip install" no Dockerfile

